### PR TITLE
Make sure JSON output compatible with standard 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "print-gtfs-rt-cli",
 	"description": "Read a GTFS Realtime feed from stdin, print human-readable or as JSON.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"files": [
 		"cli.js"
 	],

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,9 @@ Usage:
 Options:
 	--length-prefixed  -l  Read input as length-prefixed.
 	                       See https://www.npmjs.com/package/length-prefixed-stream
-	--json  -j             Output JSON instead of a pretty represenation.
+	--json  -j             Output newline-delimeted JSON instead of a pretty represenation.
+												 See http://ndjson.org/
+	--single-json -s			 Outputs standard JSON.
 Examples:
     curl 'https://example.org/gtfs-rt.pbf' | print-gtfs-rt
 ```


### PR DESCRIPTION
Current implementation seem to miss comma separating individual records and square brackets wrapping the response array
This makes sure both json and standard output include commas and square brackets for the output
Please let me know if I can provide more context or if I misunderstood the original intent
Thanks